### PR TITLE
[#7] API 요청에 대한 응답 예외 처리 추가

### DIFF
--- a/app/src/main/java/kr/yjkim/book_search/data/BookSearchRepository.kt
+++ b/app/src/main/java/kr/yjkim/book_search/data/BookSearchRepository.kt
@@ -6,6 +6,7 @@ import kotlinx.coroutines.CancellationException
 import kr.yjkim.book_search.data.network.KakaoService
 import kr.yjkim.book_search.data.network.RetrofitClient
 import kr.yjkim.book_search.data.schema.BookItem
+import kr.yjkim.book_search.util.NoDataException
 
 object BookSearchRepository {
 
@@ -13,15 +14,23 @@ object BookSearchRepository {
 
     private val _bookList: MutableLiveData<List<BookItem>> = MutableLiveData()
     val bookList: LiveData<List<BookItem>> get() = _bookList
+    private val _errorState: MutableLiveData<Throwable?> = MutableLiveData()
+    val errorState: LiveData<Throwable?> get() = _errorState
 
     suspend fun searchKeyword(keyword: String) {
-        _bookList.value = try {
+        try {
             val bookResponse = kakaoService.getBookList(keyword)
-            bookResponse.bookList
+            bookResponse.bookList.let { list ->
+                if (list.isNotEmpty()) {
+                    _bookList.value = list
+                } else {
+                    _errorState.postValue(NoDataException())
+                }
+            }
         } catch (e: CancellationException) {
             throw e
-        } catch (_: Exception) {
-            emptyList()
+        } catch (e: Exception) {
+            _errorState.postValue(e)
         }
     }
 }

--- a/app/src/main/java/kr/yjkim/book_search/data/BookSearchRepository.kt
+++ b/app/src/main/java/kr/yjkim/book_search/data/BookSearchRepository.kt
@@ -12,27 +12,23 @@ object BookSearchRepository {
 
     private val kakaoService: KakaoService = RetrofitClient.kakaoService
 
-    private val _bookList: MutableLiveData<List<BookItem>> = MutableLiveData()
-    val bookList: LiveData<List<BookItem>> get() = _bookList
-    private val _errorState: MutableLiveData<Throwable?> = MutableLiveData()
-    val errorState: LiveData<Throwable?> get() = _errorState
+    private val _searchResult: MutableLiveData<Result<List<BookItem>>> = MutableLiveData()
+    val searchResult: LiveData<Result<List<BookItem>>> get() = _searchResult
 
     suspend fun searchKeyword(keyword: String) {
-        _errorState.postValue(null)
-
         try {
             val bookResponse = kakaoService.getBookList(keyword)
-            bookResponse.bookList.let { list ->
+            _searchResult.value = bookResponse.bookList.let { list ->
                 if (list.isNotEmpty()) {
-                    _bookList.value = list
+                    Result.success(list)
                 } else {
-                    _errorState.postValue(NoDataException())
+                    Result.failure(NoDataException())
                 }
             }
         } catch (e: CancellationException) {
             throw e
         } catch (e: Exception) {
-            _errorState.postValue(e)
+            _searchResult.postValue(Result.failure(e))
         }
     }
 }

--- a/app/src/main/java/kr/yjkim/book_search/data/BookSearchRepository.kt
+++ b/app/src/main/java/kr/yjkim/book_search/data/BookSearchRepository.kt
@@ -6,7 +6,6 @@ import kotlinx.coroutines.CancellationException
 import kr.yjkim.book_search.data.network.KakaoService
 import kr.yjkim.book_search.data.network.RetrofitClient
 import kr.yjkim.book_search.data.schema.BookItem
-import kr.yjkim.book_search.util.NoDataException
 
 object BookSearchRepository {
 
@@ -18,13 +17,7 @@ object BookSearchRepository {
     suspend fun searchKeyword(keyword: String) {
         try {
             val bookResponse = kakaoService.getBookList(keyword)
-            _searchResult.value = bookResponse.bookList.let { list ->
-                if (list.isNotEmpty()) {
-                    Result.success(list)
-                } else {
-                    Result.failure(NoDataException())
-                }
-            }
+            _searchResult.value = Result.success(bookResponse.bookList)
         } catch (e: CancellationException) {
             throw e
         } catch (e: Exception) {

--- a/app/src/main/java/kr/yjkim/book_search/data/BookSearchRepository.kt
+++ b/app/src/main/java/kr/yjkim/book_search/data/BookSearchRepository.kt
@@ -18,6 +18,8 @@ object BookSearchRepository {
     val errorState: LiveData<Throwable?> get() = _errorState
 
     suspend fun searchKeyword(keyword: String) {
+        _errorState.postValue(null)
+
         try {
             val bookResponse = kakaoService.getBookList(keyword)
             bookResponse.bookList.let { list ->

--- a/app/src/main/java/kr/yjkim/book_search/ui/HomeFragment.kt
+++ b/app/src/main/java/kr/yjkim/book_search/ui/HomeFragment.kt
@@ -28,6 +28,10 @@ class HomeFragment: Fragment() {
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
 
+        vm.keyword.observe(viewLifecycleOwner) { keyword ->
+            binding.tlSearch.editText?.setText(keyword)
+        }
+
         binding.tlSearch.editText?.setOnEditorActionListener { v, actionId, _ ->
             if (actionId == EditorInfo.IME_ACTION_SEARCH) {
                 v.clearFocus()

--- a/app/src/main/java/kr/yjkim/book_search/ui/HomeViewModel.kt
+++ b/app/src/main/java/kr/yjkim/book_search/ui/HomeViewModel.kt
@@ -1,8 +1,6 @@
 package kr.yjkim.book_search.ui
 
-import androidx.lifecycle.ViewModel
-import androidx.lifecycle.ViewModelProvider
-import androidx.lifecycle.viewModelScope
+import androidx.lifecycle.*
 import androidx.lifecycle.viewmodel.initializer
 import androidx.lifecycle.viewmodel.viewModelFactory
 import kotlinx.coroutines.launch
@@ -10,10 +8,14 @@ import kr.yjkim.book_search.data.BookSearchRepository
 
 class HomeViewModel(private val repository: BookSearchRepository): ViewModel() {
 
+    private val _keyword = MutableLiveData<String>()
+    val keyword: LiveData<String> = _keyword
+
     fun searchKeyword(keyword: String) {
         viewModelScope.launch {
             repository.searchKeyword(keyword)
         }
+        _keyword.value = keyword
     }
 
     companion object {

--- a/app/src/main/java/kr/yjkim/book_search/ui/ListFragment.kt
+++ b/app/src/main/java/kr/yjkim/book_search/ui/ListFragment.kt
@@ -38,14 +38,19 @@ class ListFragment: Fragment() {
         vm.searchResult.observe(viewLifecycleOwner) { result ->
             result.fold(
                 onSuccess = { bookList ->
-                    adapter.submitList(bookList)
-                    binding.layError.visibility = View.GONE
+                    if (bookList.isEmpty()) {
+                        binding.errorText.text = getString(R.string.error_no_data)
+                        binding.layError.visibility = View.VISIBLE
+                    } else {
+                        binding.layError.visibility = View.GONE
+                        adapter.submitList(bookList)
+                    }
                 },
                 onFailure = { e ->
                     binding.errorText.text = when (e) {
                         is IOException -> getString(R.string.error_network)
                         is HttpException -> getString(R.string.error_server)
-                        else -> getString(R.string.error_no_data)
+                        else -> getString(R.string.error_unknown)
                     }
                     binding.layError.visibility = View.VISIBLE
                 })

--- a/app/src/main/java/kr/yjkim/book_search/ui/ListFragment.kt
+++ b/app/src/main/java/kr/yjkim/book_search/ui/ListFragment.kt
@@ -57,6 +57,10 @@ class ListFragment: Fragment() {
         val recyclerView = binding.recyclerBook
         recyclerView.layoutManager = LinearLayoutManager(requireContext())
         recyclerView.adapter = adapter
+
+        binding.btnTryAgain.setOnClickListener {
+            HomeViewModel(BookSearchRepository).searchKeyword(args.keyword)
+        }
     }
 
     override fun onDestroyView() {

--- a/app/src/main/java/kr/yjkim/book_search/ui/ListFragment.kt
+++ b/app/src/main/java/kr/yjkim/book_search/ui/ListFragment.kt
@@ -12,6 +12,8 @@ import kr.yjkim.book_search.R
 import kr.yjkim.book_search.adapter.BookListAdapter
 import kr.yjkim.book_search.data.BookSearchRepository
 import kr.yjkim.book_search.databinding.FragmentListBinding
+import okio.IOException
+import retrofit2.HttpException
 
 class ListFragment: Fragment() {
 
@@ -33,20 +35,20 @@ class ListFragment: Fragment() {
 
         val adapter = BookListAdapter()
 
-        vm.bookList.observe(viewLifecycleOwner) { books ->
-            adapter.submitList(books)
-            if (books.isNotEmpty()) {
-                binding.layError.visibility = View.GONE
-            }
-        }
-
-        vm.errorMessage.observe(viewLifecycleOwner) { message ->
-            if (message != null) {
-                binding.errorText.text = getString(message)
-                binding.layError.visibility = View.VISIBLE
-            } else {
-                binding.layError.visibility = View.GONE
-            }
+        vm.searchResult.observe(viewLifecycleOwner) { result ->
+            result.fold(
+                onSuccess = { bookList ->
+                    adapter.submitList(bookList)
+                    binding.layError.visibility = View.GONE
+                },
+                onFailure = { e ->
+                    binding.errorText.text = when (e) {
+                        is IOException -> getString(R.string.error_network)
+                        is HttpException -> getString(R.string.error_server)
+                        else -> getString(R.string.error_no_data)
+                    }
+                    binding.layError.visibility = View.VISIBLE
+                })
         }
 
         val toolbarTitleText = getString(R.string.toolbar_list_title, args.keyword)

--- a/app/src/main/java/kr/yjkim/book_search/ui/ListFragment.kt
+++ b/app/src/main/java/kr/yjkim/book_search/ui/ListFragment.kt
@@ -37,6 +37,13 @@ class ListFragment: Fragment() {
             adapter.submitList(books)
         }
 
+        vm.errorMessage.observe(viewLifecycleOwner) { message ->
+            message?.let {
+                binding.errorText.text = getString(it)
+                binding.layError.visibility = View.VISIBLE
+            }
+        }
+
         val toolbarTitleText = getString(R.string.toolbar_list_title, args.keyword)
         (requireActivity() as MainActivity).setToolbar(toolbarTitleText, true)
 

--- a/app/src/main/java/kr/yjkim/book_search/ui/ListFragment.kt
+++ b/app/src/main/java/kr/yjkim/book_search/ui/ListFragment.kt
@@ -66,7 +66,7 @@ class ListFragment: Fragment() {
         recyclerView.adapter = adapter
 
         binding.btnTryAgain.setOnClickListener {
-            HomeViewModel(BookSearchRepository).searchKeyword(args.keyword)
+            vm.retry(args.keyword)
         }
     }
 

--- a/app/src/main/java/kr/yjkim/book_search/ui/ListFragment.kt
+++ b/app/src/main/java/kr/yjkim/book_search/ui/ListFragment.kt
@@ -35,12 +35,17 @@ class ListFragment: Fragment() {
 
         vm.bookList.observe(viewLifecycleOwner) { books ->
             adapter.submitList(books)
+            if (books.isNotEmpty()) {
+                binding.layError.visibility = View.GONE
+            }
         }
 
         vm.errorMessage.observe(viewLifecycleOwner) { message ->
-            message?.let {
-                binding.errorText.text = getString(it)
+            if (message != null) {
+                binding.errorText.text = getString(message)
                 binding.layError.visibility = View.VISIBLE
+            } else {
+                binding.layError.visibility = View.GONE
             }
         }
 

--- a/app/src/main/java/kr/yjkim/book_search/ui/ListFragment.kt
+++ b/app/src/main/java/kr/yjkim/book_search/ui/ListFragment.kt
@@ -40,6 +40,7 @@ class ListFragment: Fragment() {
                 onSuccess = { bookList ->
                     if (bookList.isEmpty()) {
                         binding.errorText.text = getString(R.string.error_no_data)
+                        binding.btnTryAgain.visibility = View.INVISIBLE
                         binding.layError.visibility = View.VISIBLE
                     } else {
                         binding.layError.visibility = View.GONE
@@ -52,6 +53,7 @@ class ListFragment: Fragment() {
                         is HttpException -> getString(R.string.error_server)
                         else -> getString(R.string.error_unknown)
                     }
+                    binding.btnTryAgain.visibility = View.VISIBLE
                     binding.layError.visibility = View.VISIBLE
                 })
         }

--- a/app/src/main/java/kr/yjkim/book_search/ui/ListViewModel.kt
+++ b/app/src/main/java/kr/yjkim/book_search/ui/ListViewModel.kt
@@ -3,14 +3,28 @@ package kr.yjkim.book_search.ui
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider
+import androidx.lifecycle.map
 import androidx.lifecycle.viewmodel.initializer
 import androidx.lifecycle.viewmodel.viewModelFactory
+import kr.yjkim.book_search.R
 import kr.yjkim.book_search.data.BookSearchRepository
 import kr.yjkim.book_search.data.schema.BookItem
+import kr.yjkim.book_search.util.NoDataException
+import retrofit2.HttpException
+import java.io.IOException
 
 class ListViewModel(repository: BookSearchRepository): ViewModel() {
 
     val bookList: LiveData<List<BookItem>> = repository.bookList
+    val errorMessage: LiveData<Int?> = repository.errorState.map { e ->
+        when (e) {
+            null -> null
+            is IOException -> R.string.error_network
+            is HttpException -> R.string.error_server
+            is NoDataException -> R.string.error_no_data
+            else -> R.string.error_unknown
+        }
+    }
 
     companion object {
         fun create(repo: BookSearchRepository): ViewModelProvider.Factory {

--- a/app/src/main/java/kr/yjkim/book_search/ui/ListViewModel.kt
+++ b/app/src/main/java/kr/yjkim/book_search/ui/ListViewModel.kt
@@ -3,28 +3,14 @@ package kr.yjkim.book_search.ui
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider
-import androidx.lifecycle.map
 import androidx.lifecycle.viewmodel.initializer
 import androidx.lifecycle.viewmodel.viewModelFactory
-import kr.yjkim.book_search.R
 import kr.yjkim.book_search.data.BookSearchRepository
 import kr.yjkim.book_search.data.schema.BookItem
-import kr.yjkim.book_search.util.NoDataException
-import retrofit2.HttpException
-import java.io.IOException
 
 class ListViewModel(repository: BookSearchRepository): ViewModel() {
 
-    val bookList: LiveData<List<BookItem>> = repository.bookList
-    val errorMessage: LiveData<Int?> = repository.errorState.map { e ->
-        when (e) {
-            null -> null
-            is IOException -> R.string.error_network
-            is HttpException -> R.string.error_server
-            is NoDataException -> R.string.error_no_data
-            else -> R.string.error_unknown
-        }
-    }
+    val searchResult: LiveData<Result<List<BookItem>>> = repository.searchResult
 
     companion object {
         fun create(repo: BookSearchRepository): ViewModelProvider.Factory {

--- a/app/src/main/java/kr/yjkim/book_search/ui/ListViewModel.kt
+++ b/app/src/main/java/kr/yjkim/book_search/ui/ListViewModel.kt
@@ -3,14 +3,22 @@ package kr.yjkim.book_search.ui
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider
+import androidx.lifecycle.viewModelScope
 import androidx.lifecycle.viewmodel.initializer
 import androidx.lifecycle.viewmodel.viewModelFactory
+import kotlinx.coroutines.launch
 import kr.yjkim.book_search.data.BookSearchRepository
 import kr.yjkim.book_search.data.schema.BookItem
 
-class ListViewModel(repository: BookSearchRepository): ViewModel() {
+class ListViewModel(private val repository: BookSearchRepository): ViewModel() {
 
     val searchResult: LiveData<Result<List<BookItem>>> = repository.searchResult
+
+    fun retry(keyword: String) {
+        viewModelScope.launch {
+            repository.searchKeyword(keyword)
+        }
+    }
 
     companion object {
         fun create(repo: BookSearchRepository): ViewModelProvider.Factory {

--- a/app/src/main/java/kr/yjkim/book_search/util/NoDataException.kt
+++ b/app/src/main/java/kr/yjkim/book_search/util/NoDataException.kt
@@ -1,3 +1,0 @@
-package kr.yjkim.book_search.util
-
-class NoDataException(message: String = "No data available"): Exception(message)

--- a/app/src/main/java/kr/yjkim/book_search/util/NoDataException.kt
+++ b/app/src/main/java/kr/yjkim/book_search/util/NoDataException.kt
@@ -1,0 +1,3 @@
+package kr.yjkim.book_search.util
+
+class NoDataException(message: String = "No data available"): Exception(message)

--- a/app/src/main/res/layout/fragment_list.xml
+++ b/app/src/main/res/layout/fragment_list.xml
@@ -13,4 +13,38 @@
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="parent"
         tools:listitem="@layout/item_book_list" />
+
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:id="@+id/lay_error"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:background="@color/white"
+        android:visibility="gone">
+
+        <TextView
+            android:id="@+id/error_text"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:gravity="center"
+            android:paddingVertical="16dp"
+            android:textColor="@android:color/holo_red_light"
+            app:layout_constraintBottom_toTopOf="@id/btn_try_again"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent"
+            app:layout_constraintVertical_chainStyle="packed"
+            tools:text="ERROR_MESSAGE" />
+
+        <Button
+            android:id="@+id/btn_try_again"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_gravity="center"
+            android:paddingVertical="8dp"
+            android:text="@string/btn_try_again"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/error_text" />
+    </androidx.constraintlayout.widget.ConstraintLayout>
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -10,4 +10,9 @@
 
     <string name="toolbar_list_title">\"%1$s\" 검색 결과</string>
 
+    <string name="error_network">네트워크 연결을 확인해 주세요</string>
+    <string name="error_no_data">검색 결과가 없습니다</string>
+    <string name="error_server">서버 오류가 발생했습니다</string>
+    <string name="error_unknown">알 수 없는 오류가 발생했습니다</string>
+
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -15,4 +15,6 @@
     <string name="error_server">서버 오류가 발생했습니다</string>
     <string name="error_unknown">알 수 없는 오류가 발생했습니다</string>
 
+    <string name="btn_try_again">재시도</string>
+
 </resources>


### PR DESCRIPTION
## 2025.08.20 Issue #7 에 대한 PR

### 1. 예외 `catch` 설정

- `Repository` 에서 발생한 예외를 `LiveData` 객체에 담음
- `ViewModel` 에서 예외 객체를 받아 예외 유형별로 지정한 `string resource id`를 `LiveData` 객체에 담음

### 2. 예외를 UI에 표출하여 사용자의 다음 작업 유도

- `ListViewModel` 에 예외 발생 시 보여줄 `layout` 생성, `오류 문자열`과 `재시도 버튼` 포함
