### PR TITLE
[#14] LiveData 를 Flow 로 변경

### DIFF
--- a/app/src/main/java/kr/yjkim/book_search/data/BookSearchRepository.kt
+++ b/app/src/main/java/kr/yjkim/book_search/data/BookSearchRepository.kt
@@ -1,8 +1,8 @@
 package kr.yjkim.book_search.data
 
-import androidx.lifecycle.LiveData
-import androidx.lifecycle.MutableLiveData
 import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
 import kr.yjkim.book_search.data.network.KakaoService
 import kr.yjkim.book_search.data.network.RetrofitClient
 import kr.yjkim.book_search.data.schema.BookItem
@@ -11,8 +11,8 @@ object BookSearchRepository {
 
     private val kakaoService: KakaoService = RetrofitClient.kakaoService
 
-    private val _searchResult: MutableLiveData<Result<List<BookItem>>> = MutableLiveData()
-    val searchResult: LiveData<Result<List<BookItem>>> get() = _searchResult
+    private val _searchResult: MutableStateFlow<Result<List<BookItem>>> = MutableStateFlow(Result.success(listOf()))
+    val searchResult: StateFlow<Result<List<BookItem>>> get() = _searchResult
 
     suspend fun searchKeyword(keyword: String) {
         try {
@@ -21,7 +21,7 @@ object BookSearchRepository {
         } catch (e: CancellationException) {
             throw e
         } catch (e: Exception) {
-            _searchResult.postValue(Result.failure(e))
+            _searchResult.value = Result.failure(e)
         }
     }
 }

--- a/app/src/main/java/kr/yjkim/book_search/data/BookSearchRepository.kt
+++ b/app/src/main/java/kr/yjkim/book_search/data/BookSearchRepository.kt
@@ -15,6 +15,7 @@ object BookSearchRepository {
     val searchResult: StateFlow<ResultUiState> get() = _searchResult
 
     suspend fun searchKeyword(keyword: String) {
+        _searchResult.value = ResultUiState.Loading
         try {
             val bookResponse = kakaoService.getBookList(keyword)
             _searchResult.value = ResultUiState.Success(bookResponse.bookList)

--- a/app/src/main/java/kr/yjkim/book_search/data/BookSearchRepository.kt
+++ b/app/src/main/java/kr/yjkim/book_search/data/BookSearchRepository.kt
@@ -3,6 +3,7 @@ package kr.yjkim.book_search.data
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
 import kr.yjkim.book_search.data.network.KakaoService
 import kr.yjkim.book_search.data.network.RetrofitClient
 import kr.yjkim.book_search.util.ResultUiState
@@ -12,7 +13,7 @@ object BookSearchRepository {
     private val kakaoService: KakaoService = RetrofitClient.kakaoService
 
     private val _searchResult: MutableStateFlow<ResultUiState> = MutableStateFlow(ResultUiState.Loading)
-    val searchResult: StateFlow<ResultUiState> get() = _searchResult
+    val searchResult: StateFlow<ResultUiState> get() = _searchResult.asStateFlow()
 
     suspend fun searchKeyword(keyword: String) {
         _searchResult.value = ResultUiState.Loading

--- a/app/src/main/java/kr/yjkim/book_search/data/BookSearchRepository.kt
+++ b/app/src/main/java/kr/yjkim/book_search/data/BookSearchRepository.kt
@@ -5,23 +5,23 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kr.yjkim.book_search.data.network.KakaoService
 import kr.yjkim.book_search.data.network.RetrofitClient
-import kr.yjkim.book_search.data.schema.BookItem
+import kr.yjkim.book_search.util.ResultUiState
 
 object BookSearchRepository {
 
     private val kakaoService: KakaoService = RetrofitClient.kakaoService
 
-    private val _searchResult: MutableStateFlow<Result<List<BookItem>>> = MutableStateFlow(Result.success(listOf()))
-    val searchResult: StateFlow<Result<List<BookItem>>> get() = _searchResult
+    private val _searchResult: MutableStateFlow<ResultUiState> = MutableStateFlow(ResultUiState.Loading)
+    val searchResult: StateFlow<ResultUiState> get() = _searchResult
 
     suspend fun searchKeyword(keyword: String) {
         try {
             val bookResponse = kakaoService.getBookList(keyword)
-            _searchResult.value = Result.success(bookResponse.bookList)
+            _searchResult.value = ResultUiState.Success(bookResponse.bookList)
         } catch (e: CancellationException) {
             throw e
         } catch (e: Exception) {
-            _searchResult.value = Result.failure(e)
+            _searchResult.value = ResultUiState.Error(e)
         }
     }
 }

--- a/app/src/main/java/kr/yjkim/book_search/ui/HomeFragment.kt
+++ b/app/src/main/java/kr/yjkim/book_search/ui/HomeFragment.kt
@@ -7,9 +7,8 @@ import android.view.ViewGroup
 import android.view.inputmethod.EditorInfo
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.viewModels
-import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.flowWithLifecycle
 import androidx.lifecycle.lifecycleScope
-import androidx.lifecycle.repeatOnLifecycle
 import androidx.navigation.fragment.findNavController
 import kotlinx.coroutines.launch
 import kr.yjkim.book_search.data.BookSearchRepository
@@ -33,11 +32,10 @@ class HomeFragment: Fragment() {
         super.onViewCreated(view, savedInstanceState)
 
         viewLifecycleOwner.lifecycleScope.launch {
-            repeatOnLifecycle(Lifecycle.State.STARTED) {
-                vm.keyword.collect { keyword ->
+            vm.keyword.flowWithLifecycle(viewLifecycleOwner.lifecycle)
+                .collect { keyword ->
                     binding.tlSearch.editText?.setText(keyword)
                 }
-            }
         }
 
         binding.tlSearch.editText?.setOnEditorActionListener { v, actionId, _ ->

--- a/app/src/main/java/kr/yjkim/book_search/ui/HomeFragment.kt
+++ b/app/src/main/java/kr/yjkim/book_search/ui/HomeFragment.kt
@@ -7,7 +7,11 @@ import android.view.ViewGroup
 import android.view.inputmethod.EditorInfo
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.viewModels
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.lifecycleScope
+import androidx.lifecycle.repeatOnLifecycle
 import androidx.navigation.fragment.findNavController
+import kotlinx.coroutines.launch
 import kr.yjkim.book_search.data.BookSearchRepository
 import kr.yjkim.book_search.databinding.FragmentHomeBinding
 import kr.yjkim.book_search.extension.hideKeyboard
@@ -28,8 +32,12 @@ class HomeFragment: Fragment() {
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
 
-        vm.keyword.observe(viewLifecycleOwner) { keyword ->
-            binding.tlSearch.editText?.setText(keyword)
+        viewLifecycleOwner.lifecycleScope.launch {
+            repeatOnLifecycle(Lifecycle.State.STARTED) {
+                vm.keyword.collect { keyword ->
+                    binding.tlSearch.editText?.setText(keyword)
+                }
+            }
         }
 
         binding.tlSearch.editText?.setOnEditorActionListener { v, actionId, _ ->

--- a/app/src/main/java/kr/yjkim/book_search/ui/HomeViewModel.kt
+++ b/app/src/main/java/kr/yjkim/book_search/ui/HomeViewModel.kt
@@ -7,13 +7,14 @@ import androidx.lifecycle.viewmodel.initializer
 import androidx.lifecycle.viewmodel.viewModelFactory
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
 import kr.yjkim.book_search.data.BookSearchRepository
 
 class HomeViewModel(private val repository: BookSearchRepository): ViewModel() {
 
     private val _keyword: MutableStateFlow<String> = MutableStateFlow("")
-    val keyword: StateFlow<String> = _keyword
+    val keyword: StateFlow<String> = _keyword.asStateFlow()
 
     fun searchKeyword(keyword: String) {
         viewModelScope.launch {

--- a/app/src/main/java/kr/yjkim/book_search/ui/HomeViewModel.kt
+++ b/app/src/main/java/kr/yjkim/book_search/ui/HomeViewModel.kt
@@ -1,15 +1,19 @@
 package kr.yjkim.book_search.ui
 
-import androidx.lifecycle.*
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.ViewModelProvider
+import androidx.lifecycle.viewModelScope
 import androidx.lifecycle.viewmodel.initializer
 import androidx.lifecycle.viewmodel.viewModelFactory
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.launch
 import kr.yjkim.book_search.data.BookSearchRepository
 
 class HomeViewModel(private val repository: BookSearchRepository): ViewModel() {
 
-    private val _keyword = MutableLiveData<String>()
-    val keyword: LiveData<String> = _keyword
+    private val _keyword: MutableStateFlow<String> = MutableStateFlow("")
+    val keyword: StateFlow<String> = _keyword
 
     fun searchKeyword(keyword: String) {
         viewModelScope.launch {

--- a/app/src/main/java/kr/yjkim/book_search/ui/ListFragment.kt
+++ b/app/src/main/java/kr/yjkim/book_search/ui/ListFragment.kt
@@ -7,9 +7,8 @@ import android.view.ViewGroup
 import android.widget.LinearLayout
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.viewModels
-import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.flowWithLifecycle
 import androidx.lifecycle.lifecycleScope
-import androidx.lifecycle.repeatOnLifecycle
 import androidx.navigation.fragment.findNavController
 import androidx.navigation.fragment.navArgs
 import androidx.recyclerview.widget.DividerItemDecoration
@@ -47,8 +46,8 @@ class ListFragment: Fragment() {
         }
 
         viewLifecycleOwner.lifecycleScope.launch {
-            repeatOnLifecycle(Lifecycle.State.STARTED) {
-                vm.searchResult.collect { uiState ->
+            vm.searchResult.flowWithLifecycle(viewLifecycleOwner.lifecycle)
+                .collect { uiState ->
                     when (uiState) {
                         is ResultUiState.Success -> {
                             val bookList = uiState.bookList
@@ -79,7 +78,6 @@ class ListFragment: Fragment() {
                         }
                     }
                 }
-            }
         }
 
         val toolbarTitleText = getString(R.string.toolbar_list_title, args.keyword)

--- a/app/src/main/java/kr/yjkim/book_search/ui/ListFragment.kt
+++ b/app/src/main/java/kr/yjkim/book_search/ui/ListFragment.kt
@@ -7,10 +7,14 @@ import android.view.ViewGroup
 import android.widget.LinearLayout
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.viewModels
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.lifecycleScope
+import androidx.lifecycle.repeatOnLifecycle
 import androidx.navigation.fragment.findNavController
 import androidx.navigation.fragment.navArgs
 import androidx.recyclerview.widget.DividerItemDecoration
 import androidx.recyclerview.widget.LinearLayoutManager
+import kotlinx.coroutines.launch
 import kr.yjkim.book_search.R
 import kr.yjkim.book_search.adapter.BookListAdapter
 import kr.yjkim.book_search.data.BookSearchRepository
@@ -41,27 +45,31 @@ class ListFragment: Fragment() {
             findNavController().navigate(action)
         }
 
-        vm.searchResult.observe(viewLifecycleOwner) { result ->
-            result.fold(
-                onSuccess = { bookList ->
-                    if (bookList.isEmpty()) {
-                        binding.errorText.text = getString(R.string.error_no_data)
-                        binding.btnTryAgain.visibility = View.INVISIBLE
-                        binding.layError.visibility = View.VISIBLE
-                    } else {
-                        binding.layError.visibility = View.GONE
-                        adapter.submitList(bookList)
-                    }
-                },
-                onFailure = { e ->
-                    binding.errorText.text = when (e) {
-                        is IOException -> getString(R.string.error_network)
-                        is HttpException -> getString(R.string.error_server)
-                        else -> getString(R.string.error_unknown)
-                    }
-                    binding.btnTryAgain.visibility = View.VISIBLE
-                    binding.layError.visibility = View.VISIBLE
-                })
+        viewLifecycleOwner.lifecycleScope.launch {
+            repeatOnLifecycle(Lifecycle.State.STARTED) {
+                vm.searchResult.collect { result ->
+                    result.fold(
+                        onSuccess = { bookList ->
+                            if (bookList.isEmpty()) {
+                                binding.errorText.text = getString(R.string.error_no_data)
+                                binding.btnTryAgain.visibility = View.INVISIBLE
+                                binding.layError.visibility = View.VISIBLE
+                            } else {
+                                binding.layError.visibility = View.GONE
+                                adapter.submitList(bookList)
+                            }
+                        },
+                        onFailure = { e ->
+                            binding.errorText.text = when (e) {
+                                is IOException -> getString(R.string.error_network)
+                                is HttpException -> getString(R.string.error_server)
+                                else -> getString(R.string.error_unknown)
+                            }
+                            binding.btnTryAgain.visibility = View.VISIBLE
+                            binding.layError.visibility = View.VISIBLE
+                        })
+                }
+            }
         }
 
         val toolbarTitleText = getString(R.string.toolbar_list_title, args.keyword)

--- a/app/src/main/java/kr/yjkim/book_search/ui/ListFragment.kt
+++ b/app/src/main/java/kr/yjkim/book_search/ui/ListFragment.kt
@@ -19,6 +19,7 @@ import kr.yjkim.book_search.R
 import kr.yjkim.book_search.adapter.BookListAdapter
 import kr.yjkim.book_search.data.BookSearchRepository
 import kr.yjkim.book_search.databinding.FragmentListBinding
+import kr.yjkim.book_search.util.ResultUiState
 import okio.IOException
 import retrofit2.HttpException
 
@@ -47,9 +48,10 @@ class ListFragment: Fragment() {
 
         viewLifecycleOwner.lifecycleScope.launch {
             repeatOnLifecycle(Lifecycle.State.STARTED) {
-                vm.searchResult.collect { result ->
-                    result.fold(
-                        onSuccess = { bookList ->
+                vm.searchResult.collect { uiState ->
+                    when (uiState) {
+                        is ResultUiState.Success -> {
+                            val bookList = uiState.bookList
                             if (bookList.isEmpty()) {
                                 binding.errorText.text = getString(R.string.error_no_data)
                                 binding.btnTryAgain.visibility = View.INVISIBLE
@@ -58,16 +60,24 @@ class ListFragment: Fragment() {
                                 binding.layError.visibility = View.GONE
                                 adapter.submitList(bookList)
                             }
-                        },
-                        onFailure = { e ->
-                            binding.errorText.text = when (e) {
+                            binding.loadingText.visibility = View.GONE
+                        }
+
+                        is ResultUiState.Error -> {
+                            binding.errorText.text = when (uiState.exception) {
                                 is IOException -> getString(R.string.error_network)
                                 is HttpException -> getString(R.string.error_server)
                                 else -> getString(R.string.error_unknown)
                             }
                             binding.btnTryAgain.visibility = View.VISIBLE
                             binding.layError.visibility = View.VISIBLE
-                        })
+                            binding.loadingText.visibility = View.GONE
+                        }
+
+                        ResultUiState.Loading -> {
+                            binding.loadingText.visibility = View.VISIBLE
+                        }
+                    }
                 }
             }
         }

--- a/app/src/main/java/kr/yjkim/book_search/ui/ListViewModel.kt
+++ b/app/src/main/java/kr/yjkim/book_search/ui/ListViewModel.kt
@@ -8,11 +8,11 @@ import androidx.lifecycle.viewmodel.viewModelFactory
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.launch
 import kr.yjkim.book_search.data.BookSearchRepository
-import kr.yjkim.book_search.data.schema.BookItem
+import kr.yjkim.book_search.util.ResultUiState
 
 class ListViewModel(private val repository: BookSearchRepository): ViewModel() {
 
-    val searchResult: StateFlow<Result<List<BookItem>>> = repository.searchResult
+    val searchResult: StateFlow<ResultUiState> = repository.searchResult
 
     fun retry(keyword: String) {
         viewModelScope.launch {

--- a/app/src/main/java/kr/yjkim/book_search/ui/ListViewModel.kt
+++ b/app/src/main/java/kr/yjkim/book_search/ui/ListViewModel.kt
@@ -1,18 +1,18 @@
 package kr.yjkim.book_search.ui
 
-import androidx.lifecycle.LiveData
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.viewModelScope
 import androidx.lifecycle.viewmodel.initializer
 import androidx.lifecycle.viewmodel.viewModelFactory
+import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.launch
 import kr.yjkim.book_search.data.BookSearchRepository
 import kr.yjkim.book_search.data.schema.BookItem
 
 class ListViewModel(private val repository: BookSearchRepository): ViewModel() {
 
-    val searchResult: LiveData<Result<List<BookItem>>> = repository.searchResult
+    val searchResult: StateFlow<Result<List<BookItem>>> = repository.searchResult
 
     fun retry(keyword: String) {
         viewModelScope.launch {

--- a/app/src/main/java/kr/yjkim/book_search/util/ResultUiState.kt
+++ b/app/src/main/java/kr/yjkim/book_search/util/ResultUiState.kt
@@ -1,0 +1,9 @@
+package kr.yjkim.book_search.util
+
+import kr.yjkim.book_search.data.schema.BookItem
+
+sealed class ResultUiState {
+    object Loading: ResultUiState()
+    data class Success(val bookList: List<BookItem>): ResultUiState()
+    data class Error(val exception: Throwable): ResultUiState()
+}

--- a/app/src/main/res/layout/fragment_list.xml
+++ b/app/src/main/res/layout/fragment_list.xml
@@ -14,6 +14,18 @@
         app:layout_constraintTop_toTopOf="parent"
         tools:listitem="@layout/item_book_list" />
 
+    <TextView
+        android:id="@+id/loading_text"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:gravity="center"
+        android:text="@string/loading"
+        android:visibility="gone"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
+
     <androidx.constraintlayout.widget.ConstraintLayout
         android:id="@+id/lay_error"
         android:layout_width="match_parent"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -10,6 +10,7 @@
 
     <string name="toolbar_list_title">\"%1$s\" 검색 결과</string>
 
+    <string name="loading">검색 중...</string>
     <string name="error_network">네트워크 연결을 확인해 주세요</string>
     <string name="error_no_data">검색 결과가 없습니다</string>
     <string name="error_server">서버 오류가 발생했습니다</string>


### PR DESCRIPTION
## 2025.09.24. Issue #14 에 대한 PR

### 1. `LiveData` 를 `Flow` 로 변경하기
- `LiveData`, `MutableLiveData` 를 각각 `StateFlow`, `MutableStateFlow` 로 변경
- UI 의 `Lifecycle` 이 `STARTED` 일 때 시작하도록 `repeatOnLifecycle(Lifecycle.State.STARTED)` 설정

### 2. 추가 변경사항
- 당초 `MutableStateFlow` 의 초기값이 필요하여 `Result.success(listOf())` 로 설정하였으나,
`Result.success` 일 때 응답 데이터 리스트가 비어 있으므로 _"검색 결과가 없습니다"_ 메세지 표출되는 문제
-> _검색이 진행되고 있음_ 을 나타내는 상태 값(`Loading`)을 추가한 별도 클래스 생성
- 최초 검색 이후에 다시 검색할 경우, 이전 검색 상태가 `StateFlow` 에 저장되어 있는 상태이므로
새로운 검색이 진행되는 동안 이전 검색 상태가 그대로 보여지는 문제
-> 검색을 시작하면 `StateFlow` 에 다시 초기값(`Loading`)을 강제로 주입
